### PR TITLE
test: add unit tests for utils modules

### DIFF
--- a/src/utils/__tests__/dom.test.ts
+++ b/src/utils/__tests__/dom.test.ts
@@ -1,0 +1,146 @@
+import { Element, Text, Node } from "domhandler";
+import { describe, expect, it } from "vitest";
+import { findOne, getText, queryOne } from "../dom";
+
+describe("dom utilities", () => {
+  describe("findOne", () => {
+    it("should find element matching predicate", () => {
+      const node: Node = new Element("div", {}, [
+        new Element("span", { id: "target" }, [new Text("test", "text")]),
+      ]);
+      const result = findOne((el) => el.attribs?.id === "target", [node]);
+      expect(result?.name).toBe("span");
+      expect(result?.attribs?.id).toBe("target");
+    });
+
+    it("should return null if no match found", () => {
+      const node: Node = new Element("div", {}, [
+        new Element("span", {}, [new Text("test", "text")]),
+      ]);
+      const result = findOne(
+        (el) => el.attribs?.id === "nonexistent",
+        [node],
+      );
+      expect(result).toBeNull();
+    });
+
+    it("should recurse into children by default", () => {
+      const node: Node = new Element("div", {}, [
+        new Element("p", {}, [
+          new Element("span", { id: "deep" }, [new Text("deep", "text")]),
+        ]),
+      ]);
+      const result = findOne((el) => el.attribs?.id === "deep", [node]);
+      expect(result?.name).toBe("span");
+    });
+
+    it("should not recurse when recurse is false", () => {
+      const node: Node = new Element("div", {}, [
+        new Element("p", {}, [
+          new Element("span", { id: "deep" }, [new Text("deep", "text")]),
+        ]),
+      ]);
+      const result = findOne(
+        (el) => el.attribs?.id === "deep",
+        [node],
+        false,
+      );
+      expect(result).toBeNull();
+    });
+
+    it("should handle array of nodes", () => {
+      const nodes: Node[] = [
+        new Element("span", { id: "first" }, [new Text("a", "text")]),
+        new Element("span", { id: "second" }, [new Text("b", "text")]),
+      ];
+      const result = findOne((el) => el.attribs?.id === "second", nodes);
+      expect(result?.attribs?.id).toBe("second");
+    });
+  });
+
+  describe("getText", () => {
+    it("should return empty string for null input", () => {
+      expect(getText(null)).toBe("");
+    });
+
+    it("should return empty string for undefined input", () => {
+      expect(getText(undefined)).toBe("");
+    });
+
+    it("should get text from a text node", () => {
+      const textNode = new Text("Hello World", "text");
+      expect(getText(textNode)).toBe("Hello World");
+    });
+
+    it("should handle br tags as newlines", () => {
+      const br = new Element("br", {});
+      expect(getText(br)).toBe("\n");
+    });
+
+    it("should handle element with children", () => {
+      const div = new Element("div", {}, [
+        new Text("Hello", "text"),
+        new Text("World", "text"),
+      ]);
+      expect(getText(div)).toBe("HelloWorld");
+    });
+
+    it("should handle array of nodes", () => {
+      const nodes: Node[] = [
+        new Text("a", "text"),
+        new Text("b", "text"),
+      ];
+      expect(getText(nodes)).toBe("ab");
+    });
+
+    it("should trim whitespace from text nodes", () => {
+      const textNode = new Text("  trimmed  ", "text");
+      expect(getText(textNode)).toBe("trimmed");
+    });
+  });
+
+  describe("queryOne", () => {
+    it("should find element by class name", () => {
+      const node: Node = new Element("div", {}, [
+        new Element("span", { class: "target" }, [new Text("test", "text")]),
+      ]);
+      const result = queryOne([node], "target");
+      expect(result?.name).toBe("span");
+    });
+
+    it("should return null if class not found", () => {
+      const node: Node = new Element("div", {}, [
+        new Element("span", { class: "other" }, [new Text("test", "text")]),
+      ]);
+      const result = queryOne([node], "target");
+      expect(result).toBeNull();
+    });
+
+    it("should filter by tag name when provided", () => {
+      const node: Node = new Element("div", {}, [
+        new Element("span", { class: "target" }, [new Text("span", "text")]),
+        new Element("div", { class: "target" }, [new Text("div", "text")]),
+      ]);
+      const result = queryOne([node], "target", "div");
+      expect(result?.name).toBe("div");
+    });
+
+    it("should return null if tag name doesn't match", () => {
+      const node: Node = new Element("div", {}, [
+        new Element("span", { class: "target" }, [new Text("span", "text")]),
+      ]);
+      const result = queryOne([node], "target", "div");
+      expect(result).toBeNull();
+    });
+
+    it("should handle multiple classes", () => {
+      const node: Node = new Element("div", {}, [
+        new Element("span", { class: "foo bar baz" }, [
+          new Text("test", "text"),
+        ]),
+      ]);
+      const result = queryOne([node], "bar");
+      expect(result).not.toBeNull();
+    });
+  });
+});

--- a/src/utils/__tests__/fetch-text.test.ts
+++ b/src/utils/__tests__/fetch-text.test.ts
@@ -1,0 +1,92 @@
+import { fetch } from "undici";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchText } from "../fetch-text";
+
+vi.mock("undici", () => ({
+  fetch: vi.fn(),
+}));
+
+const mockedFetch = fetch as ReturnType<typeof vi.fn>;
+
+describe("fetchText", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should fetch and return text from URL", async () => {
+    mockedFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: async () => "Hello World",
+    } as Response);
+
+    const result = await fetchText("https://example.com");
+    expect(result).toBe("Hello World");
+    expect(mockedFetch).toHaveBeenCalledWith(
+      "https://example.com",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "User-Agent": "Mozilla/5.0",
+        }),
+      }),
+    );
+  });
+
+  it("should throw error for non-OK responses", async () => {
+    mockedFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      text: async () => "Not Found",
+    } as Response);
+
+    await expect(fetchText("https://example.com")).rejects.toThrow(
+      "404 Not Found: https://example.com",
+    );
+  });
+
+  it("should accept custom headers", async () => {
+    mockedFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: async () => "result",
+    } as Response);
+
+    await fetchText("https://example.com", {
+      headers: { "Custom-Header": "value" },
+    });
+
+    expect(mockedFetch).toHaveBeenCalledWith(
+      "https://example.com",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "Custom-Header": "value",
+        }),
+      }),
+    );
+  });
+
+  it("should allow overriding default headers", async () => {
+    mockedFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: async () => "result",
+    } as Response);
+
+    await fetchText("https://example.com", {
+      headers: { "User-Agent": "CustomAgent" },
+    });
+
+    expect(mockedFetch).toHaveBeenCalledWith(
+      "https://example.com",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "User-Agent": "CustomAgent",
+        }),
+      }),
+    );
+  });
+});

--- a/src/utils/__tests__/parse.test.ts
+++ b/src/utils/__tests__/parse.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  parseNum,
+  parseVersion,
+  isPlainObject,
+  toPlainObject,
+  toArray,
+  toStr,
+  tryJSONParseObject,
+} from "../parse";
+
+describe("parse utilities", () => {
+  describe("parseNum", () => {
+    it("should parse valid number strings", () => {
+      expect(parseNum("123")).toBe(123);
+      expect(parseNum("45.67")).toBe(45.67);
+    });
+
+    it("should handle numbers with commas", () => {
+      expect(parseNum("1,234,567")).toBe(1234567);
+      expect(parseNum("1,234.56")).toBe(1234.56);
+    });
+
+    it("should handle numbers with prefix characters", () => {
+      expect(parseNum("$100")).toBe(100);
+      expect(parseNum("about 50")).toBe(50);
+    });
+
+    it("should return null for invalid input", () => {
+      expect(parseNum("")).toBeNull();
+      expect(parseNum("abc")).toBeNull();
+      expect(parseNum(null)).toBeNull();
+      expect(parseNum(undefined)).toBeNull();
+    });
+
+    it("should pass through numbers", () => {
+      expect(parseNum(42)).toBe(42);
+      expect(parseNum(3.14)).toBe(3.14);
+    });
+  });
+
+  describe("parseVersion", () => {
+    it("should parse semantic versions", () => {
+      expect(parseVersion("1.0.0")).toBe("1.0.0");
+      expect(parseVersion("2.3.4")).toBe("2.3.4");
+    });
+
+    it("should handle v prefix", () => {
+      expect(parseVersion("v1.0.0")).toBe("1.0.0");
+      expect(parseVersion("v2.3.4")).toBe("2.3.4");
+    });
+
+    it("should handle complex version strings", () => {
+      expect(parseVersion("Version 1.2.3")).toBe("1.2.3");
+      expect(parseVersion("v1.2.3-beta")).toBe("1.2.3");
+    });
+
+    it("should return null for invalid input", () => {
+      expect(parseVersion("")).toBeNull();
+      expect(parseVersion("no version")).toBeNull();
+      expect(parseVersion(null)).toBeNull();
+      expect(parseVersion(undefined)).toBeNull();
+    });
+  });
+
+  describe("isPlainObject", () => {
+    it("should return true for plain objects", () => {
+      expect(isPlainObject({})).toBe(true);
+      expect(isPlainObject({ a: 1 })).toBe(true);
+    });
+
+    it("should return false for non-objects", () => {
+      expect(isPlainObject(null)).toBe(false);
+      expect(isPlainObject(undefined)).toBe(false);
+      expect(isPlainObject("string")).toBe(false);
+      expect(isPlainObject(123)).toBe(false);
+    });
+
+    it("should return false for arrays", () => {
+      expect(isPlainObject([])).toBe(false);
+      expect(isPlainObject([1, 2, 3])).toBe(false);
+    });
+
+    it("should return false for built-in objects", () => {
+      expect(isPlainObject(new Date())).toBe(false);
+      expect(isPlainObject(/regex/)).toBe(false);
+    });
+  });
+
+  describe("toPlainObject", () => {
+    it("should return plain objects", () => {
+      expect(toPlainObject({})).toEqual({});
+      expect(toPlainObject({ a: 1 })).toEqual({ a: 1 });
+    });
+
+    it("should return undefined for non-plain objects", () => {
+      expect(toPlainObject(null)).toBeUndefined();
+      expect(toPlainObject([])).toBeUndefined();
+      expect(toPlainObject("string")).toBeUndefined();
+    });
+  });
+
+  describe("toArray", () => {
+    it("should return arrays", () => {
+      expect(toArray([])).toEqual([]);
+      expect(toArray([1, 2, 3])).toEqual([1, 2, 3]);
+    });
+
+    it("should return undefined for non-arrays", () => {
+      expect(toArray(null)).toBeUndefined();
+      expect(toArray({})).toBeUndefined();
+      expect(toArray("string")).toBeUndefined();
+    });
+  });
+
+  describe("toStr", () => {
+    it("should return trimmed strings", () => {
+      expect(toStr("hello")).toBe("hello");
+      expect(toStr("  trimmed  ")).toBe("trimmed");
+    });
+
+    it("should return null for empty strings", () => {
+      expect(toStr("")).toBeNull();
+      expect(toStr("   ")).toBeNull();
+    });
+
+    it("should return null for non-strings", () => {
+      expect(toStr(null)).toBeNull();
+      expect(toStr(123)).toBeNull();
+      expect(toStr({})).toBeNull();
+    });
+  });
+
+  describe("tryJSONParseObject", () => {
+    it("should parse valid JSON objects", () => {
+      expect(tryJSONParseObject('{"a": 1}')).toEqual({ a: 1 });
+      expect(tryJSONParseObject("{}")).toEqual({});
+    });
+
+    it("should return undefined for invalid JSON", () => {
+      expect(tryJSONParseObject("not json")).toBeUndefined();
+      expect(tryJSONParseObject("[1, 2, 3]")).toBeUndefined();
+      expect(tryJSONParseObject("")).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add comprehensive unit tests for the previously untested utility modules in `src/utils/`:

- **dom.ts**: Tests for `findOne`, `getText`, and `queryOne` functions (17 tests)
- **parse.ts**: Tests for `parseNum`, `parseVersion`, `isPlainObject`, `toPlainObject`, `toArray`, `toStr`, and `tryJSONParseObject` (22 tests)  
- **fetch-text.ts**: Tests for `fetchText` utility with mocked HTTP calls (4 tests)

## Test Results

All 67 tests pass (24 existing + 43 new):

```
✓ src/utils/__tests__/fetch-text.test.ts (4 tests)
✓ src/utils/__tests__/dom.test.ts (17 tests)
✓ src/utils/__tests__/parse.test.ts (22 tests)
✓ src/amo/__tests__/amo.test.ts (10 tests)
✓ src/chrome-web-store/__tests__/chrome-web-store.test.ts (14 tests)
```

## Coverage Improvement

These tests increase code coverage for the utility modules that previously had zero test coverage.
